### PR TITLE
Publish XML alongside TXT and HTML on gh-pages

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -54,5 +54,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: |
+          draft-*.xml
           draft-*.html
           draft-*.txt


### PR DESCRIPTION
Currently TXT and HTML versions are pushed to the gh-pages branch when a PR is merged.
This PR updates the process to also publish the XML.